### PR TITLE
[Fixed] Long text in clipboard

### DIFF
--- a/PasteRepeater.py
+++ b/PasteRepeater.py
@@ -3,7 +3,7 @@ import sublime, sublime_plugin
 class RepeaterCommand(sublime_plugin.TextCommand):
   def run(self, edit):
     clip = sublime.get_clipboard();
-    self.view.window().show_input_panel("(%s)Paste how many times?" % clip, "", self.on_done, None, None)
+    self.view.window().show_input_panel("Paste how many times?", "", self.on_done, None, None)
 
   def on_done(self, user_input):
     pasteCount = int(float(user_input))


### PR DESCRIPTION
### 1. Settings

For example, I select code:

```json
"kristina_monamour": {
    "caption": "Color Scheme Units: Show Scope Name",
    "call": "sublime.show_scope_name_and_styles"
},
```

I run `paste_repeater` command.

### 2. Behavior before pull request

My symbols don't fit in input panel:

![Input panel](http://i.imgur.com/yftJ4XS.png)

### 3. Behavior after pull request

Clipboard content don't paste into input panel.

![Right input panel](http://i.imgur.com/iHwwLMT.png)


Thanks.